### PR TITLE
Adding support for Docker Compose and automatic updates of the minimum version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3"
+
+services:
+  hugo:
+    image: jojomi/hugo:0.65.0
+    container_name: "hugo-academic"
+    restart: unless-stopped
+    environment:
+      - HUGO_THEME=academic
+      - HUGO_WATCH=1
+      # - HUGO_DESTINATION=/output
+      - HUGO_REFRESH_TIME=60
+      # - HUGO_BASEURL=<your-url-here>
+    volumes:
+      - .:/src
+      # - ./output:/output
+    ports: [ "1313:1313", ]
+    command:
+      - /run.sh
+      - --disableFastRender

--- a/update_academic.sh
+++ b/update_academic.sh
@@ -25,13 +25,17 @@ function do_update () {
   # Apply any updates
   git submodule update --remote --merge
 
+  # Postfix '.0' to Hugo min_version as sadly it doesn't map to a precise semantic version.
+  version=$(sed -n 's/^min_version = //p' themes/academic/theme.toml | tr -d '"')
+  version="${version}.0"
   # - Update Netlify.toml with required Hugo version
   if [ -f ./netlify.toml ]; then
-    # Postfix '.0' to Hugo min_version as sadly it doesn't map to a precise semantic version.
-    version=$(sed -n 's/^min_version = //p' themes/academic/theme.toml | tr -d '"')
-    version="${version}.0"
     echo "Set Netlify Hugo version to v${version}"
     sed -i.bak -e "s/HUGO_VERSION = .*/HUGO_VERSION = \"$version\"/g" ./netlify.toml && rm -f ./netlify.toml.bak
+  fi
+  if [ -f ./docker-compose.yml ]; then
+    echo "Set Docker Hugo version to v${version}"
+    sed -i.bak -e "s|jojomi/hugo:.*|jojomi/hugo:"${version}"|g" ./docker-compose.yml && rm -f ./docker-compose.yml.bak
   fi
 
   echo


### PR DESCRIPTION
I have a personal preference to using Docker when developing. As a result, I'm hoping that `hugo-academic` might also help in pushing more users/develops to use containers during development for "guaranteed functionality."

I haven't added anything to the `hugo-academic` docs, just yet – but if this PR is pushed through, I'll definitely add some instructions there.