### PR TITLE
Add security headers to demo site in netlify.toml

### DIFF
--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -282,3 +282,24 @@ plugins_js  = []
 ############################
 [icon.pack]
   ai = false  # Academicons icon pack https://jpswalsh.github.io/academicons/
+
+[security]
+[security.csp]
+  policy = '''
+    default-src 'self';
+    connect-src 'self' api.github.com www.netlifystatus.com;
+    font-src data: cdn.jsdelivr.net cdnjs.cloudflare.com fonts.gstatic.com;
+    img-src 'self' data: blob: a.tile.openstreetmap.org b.tile.openstreetmap.org c.tile.openstreetmap.org cdnjs.cloudflare.com; manifest-src 'self';
+    script-src 'self' 'unsafe-inline' 'unsafe-eval' buttons.github.io cdn.jsdelivr.net cdnjs.cloudflare.com identity.netlify.com cdn.mathjax.org;
+    style-src 'self' 'unsafe-inline' cdnjs.cloudflare.com fonts.googleapis.com;
+    form-action 'none';
+    frame-ancestors 'none';
+    object-src 'none';
+    base-uri 'none';
+    upgrade-insecure-requests;
+    report-uri https://julenetxaniz.report-uri.com/r/d/csp/enforce
+    '''
+  report_only = false
+  
+[security.permissions]
+  policy = "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()"

--- a/exampleSite/netlify.toml
+++ b/exampleSite/netlify.toml
@@ -29,8 +29,16 @@
   for = "/*"
   [headers.values]
     Content-Security-Policy-Report-Only = '''
-    default-src 'none';
+    default-src 'self';
+    connect-src 'self' api.github.com www.netlifystatus.com;
+    font-src data: cdn.jsdelivr.net cdnjs.cloudflare.com fonts.gstatic.com;
+    img-src 'self' data: blob: a.tile.openstreetmap.org b.tile.openstreetmap.org c.tile.openstreetmap.org cdnjs.cloudflare.com; manifest-src 'self';
+    script-src 'self' 'unsafe-inline' 'unsafe-eval' buttons.github.io cdn.jsdelivr.net cdnjs.cloudflare.com identity.netlify.com;
+    style-src 'self' 'unsafe-inline' cdnjs.cloudflare.com fonts.googleapis.com;
     form-action 'none';
     frame-ancestors 'none';
-    report-uri https://julenetxaniz.report-uri.com/r/d/csp/wizard
+    object-src 'none';
+    base-uri 'none';
+    upgrade-insecure-requests;
+    report-uri https://julenetxaniz.report-uri.com/r/d/csp/reportOnly
     '''

--- a/exampleSite/netlify.toml
+++ b/exampleSite/netlify.toml
@@ -24,25 +24,3 @@
   for = "index.xml"
   [headers.values]
     Content-Type = "application/rss+xml"
-
-[[headers]]
-  for = "/*"
-  [headers.values]
-    Content-Security-Policy = '''
-    default-src 'self';
-    connect-src 'self' api.github.com www.netlifystatus.com;
-    font-src data: cdn.jsdelivr.net cdnjs.cloudflare.com fonts.gstatic.com;
-    img-src 'self' data: blob: a.tile.openstreetmap.org b.tile.openstreetmap.org c.tile.openstreetmap.org cdnjs.cloudflare.com; manifest-src 'self';
-    script-src 'self' 'unsafe-inline' 'unsafe-eval' buttons.github.io cdn.jsdelivr.net cdnjs.cloudflare.com identity.netlify.com cdn.mathjax.org;
-    style-src 'self' 'unsafe-inline' cdnjs.cloudflare.com fonts.googleapis.com;
-    form-action 'none';
-    frame-ancestors 'none';
-    object-src 'none';
-    base-uri 'none';
-    upgrade-insecure-requests;
-    report-uri https://julenetxaniz.report-uri.com/r/d/csp/enforce
-    '''
-    X-Content-Type-Options = "nosniff"
-    Referrer-Policy	= "strict-origin-when-cross-origin"
-    Feature-Policy = "accelerometer 'none'; camera 'none'; geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; payment 'none'; usb 'none'"
-    Permissions-Policy = "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()"

--- a/exampleSite/netlify.toml
+++ b/exampleSite/netlify.toml
@@ -44,3 +44,5 @@
     '''
     X-Content-Type-Options = "nosniff"
     Referrer-Policy	= "strict-origin-when-cross-origin"
+    Feature-Policy = "accelerometer 'none'; camera 'none'; geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; payment 'none'; usb 'none'"
+    Permissions-Policy = "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()"

--- a/exampleSite/netlify.toml
+++ b/exampleSite/netlify.toml
@@ -24,3 +24,13 @@
   for = "index.xml"
   [headers.values]
     Content-Type = "application/rss+xml"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Content-Security-Policy-Report-Only = '''
+    default-src 'none';
+    form-action 'none';
+    frame-ancestors 'none';
+    report-uri https://julenetxaniz.report-uri.com/r/d/csp/wizard
+    '''

--- a/exampleSite/netlify.toml
+++ b/exampleSite/netlify.toml
@@ -43,3 +43,4 @@
     report-uri https://julenetxaniz.report-uri.com/r/d/csp/enforce
     '''
     X-Content-Type-Options = "nosniff"
+    Referrer-Policy	= "strict-origin-when-cross-origin"

--- a/exampleSite/netlify.toml
+++ b/exampleSite/netlify.toml
@@ -42,3 +42,4 @@
     upgrade-insecure-requests;
     report-uri https://julenetxaniz.report-uri.com/r/d/csp/enforce
     '''
+    X-Content-Type-Options = "nosniff"

--- a/exampleSite/netlify.toml
+++ b/exampleSite/netlify.toml
@@ -28,17 +28,17 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy-Report-Only = '''
+    Content-Security-Policy = '''
     default-src 'self';
     connect-src 'self' api.github.com www.netlifystatus.com;
     font-src data: cdn.jsdelivr.net cdnjs.cloudflare.com fonts.gstatic.com;
     img-src 'self' data: blob: a.tile.openstreetmap.org b.tile.openstreetmap.org c.tile.openstreetmap.org cdnjs.cloudflare.com; manifest-src 'self';
-    script-src 'self' 'unsafe-inline' 'unsafe-eval' buttons.github.io cdn.jsdelivr.net cdnjs.cloudflare.com identity.netlify.com;
+    script-src 'self' 'unsafe-inline' 'unsafe-eval' buttons.github.io cdn.jsdelivr.net cdnjs.cloudflare.com identity.netlify.com cdn.mathjax.org;
     style-src 'self' 'unsafe-inline' cdnjs.cloudflare.com fonts.googleapis.com;
     form-action 'none';
     frame-ancestors 'none';
     object-src 'none';
     base-uri 'none';
     upgrade-insecure-requests;
-    report-uri https://julenetxaniz.report-uri.com/r/d/csp/reportOnly
+    report-uri https://julenetxaniz.report-uri.com/r/d/csp/enforce
     '''


### PR DESCRIPTION
### Purpose

This PR adds 5 security headers to the https://academic-demo.netlify.app/ site. This could be useful as an example for anyone that wants to add security headers to their site.

Currently, the demo site only includes the `Strict-Transport-Security` header and has a bad score in [Security Headers](https://securityheaders.com/?q=academic-demo.netlify.app&followRedirects=on). 

![image](https://user-images.githubusercontent.com/48165265/103422315-18a1b200-4ba1-11eb-984f-48e9f9e5d995.png)

I have added the remaining headers to `netlify.toml`. I have used [Report URI](https://report-uri.com/) to ease the configuration of `Content-Security-Policy`. You can check the demo with added headers here: https://academic-demo-headers.netlify.app/. The score in [Security Headers](https://securityheaders.com/?q=academic-demo-headers.netlify.app&followRedirects=on) improves from D to A.

![image](https://user-images.githubusercontent.com/48165265/103422575-78e52380-4ba2-11eb-8caf-c06afde9435b.png)